### PR TITLE
Fix `Cannot find module 'https-proxy-agent'` error

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,14 @@
     "type": "git",
     "url": "git://github.com/holidayextras/node-saucelabs.git"
   },
+  "dependencies": {
+    "https-proxy-agent": "1.0.0"
+  },
   "devDependencies": {
     "jshint": "*",
     "mocha": "1.9.x",
     "chai": "1.5.x",
     "nock": "0.17.x",
-    "https-proxy-agent": "1.0.0",
     "url": "0.11.0"
   },
   "engines": {


### PR DESCRIPTION
If I `npm install saucelabs`, the `https-proxy-agent` dependency added in v0.2 is not installed.

Current workaround: `npm install saucelabs@0.1.1`.

Btw, using `1.0.x` or `^1.0.0` would probably be better than hardcoding the dependency version that much…